### PR TITLE
Security fixes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0071", # `time` localtime_r segfault
+    "RUSTSEC-2020-0159", # `chrono` localtime_r segfault
+]
+
+[output]
+quiet = false
+deny = ["warnings"]
+


### PR DESCRIPTION
Ignore these 2 warnings as these functions are not in use.
These suppressions will be removed once upstream get updated